### PR TITLE
update usage description with correct effect count

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This creates an image that can only be seen while its playing.
 
 ## Usage
 
-All you have to do is add one of the three effects (**CyclingNoiseEffect**, **SlidingNoiseEffect**, **VariableSlidingNoiseEffect**, or **ColorfulNoiseEffect**) to your camera's compositor effects.
+All you have to do is add one of the four effects (**CyclingNoiseEffect**, **SlidingNoiseEffect**, **VariableSlidingNoiseEffect**, or **ColorfulNoiseEffect**) to your camera's compositor effects.
 To make the effect good, the scene's setup needs to work well with the shader.
 In the first person demo, I give the player camera an **OmniLight3D**, which makes closer objects brighter.
 I also recommend making the sky black, so it doesn't interfere with the noise.


### PR DESCRIPTION
Presumably there used to only be 3 effects, but in any case there are 4 listed now.